### PR TITLE
fix: add version 2 to goreleaser configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,8 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+
+version: 2
+
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
## Summary
- Added `version: 2` to the goreleaser configuration file
- This fixes the failing release workflow that was preventing project releases

## Details
GoReleaser v2 requires configuration files to specify `version: 2`. The workflow was failing with the error:
```
only version: 2 configuration files are supported, yours is version: 0, please update your configuration
```

## Test plan
- [x] Added version 2 to .goreleaser.yaml
- [ ] Verify that the release workflow runs successfully with the updated config
- [ ] Test by creating a release tag once merged