### PR TITLE
feat: add STOP_WATCHING status support to remove recording rules

### DIFF
--- a/annict/generated.go
+++ b/annict/generated.go
@@ -98,6 +98,99 @@ func (v *GetOnHoldWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConn
 	return v.StartedAt
 }
 
+// GetStopWatchingWorksResponse is returned by GetStopWatchingWorks on success.
+type GetStopWatchingWorksResponse struct {
+	Viewer GetStopWatchingWorksViewerUser `json:"viewer"`
+}
+
+// GetViewer returns GetStopWatchingWorksResponse.Viewer, and is useful for accessing the field via an interface.
+func (v *GetStopWatchingWorksResponse) GetViewer() GetStopWatchingWorksViewerUser { return v.Viewer }
+
+// GetStopWatchingWorksViewerUser includes the requested fields of the GraphQL type User.
+type GetStopWatchingWorksViewerUser struct {
+	Works GetStopWatchingWorksViewerUserWorksWorkConnection `json:"works"`
+}
+
+// GetWorks returns GetStopWatchingWorksViewerUser.Works, and is useful for accessing the field via an interface.
+func (v *GetStopWatchingWorksViewerUser) GetWorks() GetStopWatchingWorksViewerUserWorksWorkConnection {
+	return v.Works
+}
+
+// GetStopWatchingWorksViewerUserWorksWorkConnection includes the requested fields of the GraphQL type WorkConnection.
+// The GraphQL type's documentation follows.
+//
+// The connection type for Work.
+type GetStopWatchingWorksViewerUserWorksWorkConnection struct {
+	// A list of nodes.
+	Nodes []GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork `json:"nodes"`
+}
+
+// GetNodes returns GetStopWatchingWorksViewerUserWorksWorkConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *GetStopWatchingWorksViewerUserWorksWorkConnection) GetNodes() []GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork {
+	return v.Nodes
+}
+
+// GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork includes the requested fields of the GraphQL type Work.
+// The GraphQL type's documentation follows.
+//
+// An anime title
+type GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork struct {
+	AnnictId   int                                                                                 `json:"annictId"`
+	Title      string                                                                              `json:"title"`
+	SeasonName SeasonName                                                                          `json:"seasonName"`
+	SeasonYear int                                                                                 `json:"seasonYear"`
+	Programs   GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection `json:"programs"`
+}
+
+// GetAnnictId returns GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork.AnnictId, and is useful for accessing the field via an interface.
+func (v *GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork) GetAnnictId() int {
+	return v.AnnictId
+}
+
+// GetTitle returns GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork.Title, and is useful for accessing the field via an interface.
+func (v *GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork) GetTitle() string {
+	return v.Title
+}
+
+// GetSeasonName returns GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork.SeasonName, and is useful for accessing the field via an interface.
+func (v *GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork) GetSeasonName() SeasonName {
+	return v.SeasonName
+}
+
+// GetSeasonYear returns GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork.SeasonYear, and is useful for accessing the field via an interface.
+func (v *GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork) GetSeasonYear() int {
+	return v.SeasonYear
+}
+
+// GetPrograms returns GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork.Programs, and is useful for accessing the field via an interface.
+func (v *GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWork) GetPrograms() GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection {
+	return v.Programs
+}
+
+// GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection includes the requested fields of the GraphQL type ProgramConnection.
+// The GraphQL type's documentation follows.
+//
+// The connection type for Program.
+type GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection struct {
+	// A list of nodes.
+	Nodes []GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram `json:"nodes"`
+}
+
+// GetNodes returns GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection) GetNodes() []GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram {
+	return v.Nodes
+}
+
+// GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram includes the requested fields of the GraphQL type Program.
+type GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram struct {
+	StartedAt time.Time `json:"startedAt"`
+}
+
+// GetStartedAt returns GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram.StartedAt, and is useful for accessing the field via an interface.
+func (v *GetStopWatchingWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram) GetStartedAt() time.Time {
+	return v.StartedAt
+}
+
 // GetWannaWatchWorksResponse is returned by GetWannaWatchWorks on success.
 type GetWannaWatchWorksResponse struct {
 	Viewer GetWannaWatchWorksViewerUser `json:"viewer"`
@@ -292,7 +385,7 @@ const (
 const GetOnHoldWorks_Operation = `
 query GetOnHoldWorks {
 	viewer {
-		works(state: WATCHING) {
+		works(state: ON_HOLD) {
 			nodes {
 				annictId
 				title
@@ -320,6 +413,49 @@ func GetOnHoldWorks(
 	var err_ error
 
 	var data_ GetOnHoldWorksResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by GetStopWatchingWorks.
+const GetStopWatchingWorks_Operation = `
+query GetStopWatchingWorks {
+	viewer {
+		works(state: STOP_WATCHING) {
+			nodes {
+				annictId
+				title
+				seasonName
+				seasonYear
+				programs(first: 1) {
+					nodes {
+						startedAt
+					}
+				}
+			}
+		}
+	}
+}
+`
+
+func GetStopWatchingWorks(
+	ctx_ context.Context,
+	client_ graphql.Client,
+) (*GetStopWatchingWorksResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "GetStopWatchingWorks",
+		Query:  GetStopWatchingWorks_Operation,
+	}
+	var err_ error
+
+	var data_ GetStopWatchingWorksResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/annict/generated.go
+++ b/annict/generated.go
@@ -282,6 +282,95 @@ func (v *GetWannaWatchWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgram
 	return v.StartedAt
 }
 
+// GetWatchedWorksResponse is returned by GetWatchedWorks on success.
+type GetWatchedWorksResponse struct {
+	Viewer GetWatchedWorksViewerUser `json:"viewer"`
+}
+
+// GetViewer returns GetWatchedWorksResponse.Viewer, and is useful for accessing the field via an interface.
+func (v *GetWatchedWorksResponse) GetViewer() GetWatchedWorksViewerUser { return v.Viewer }
+
+// GetWatchedWorksViewerUser includes the requested fields of the GraphQL type User.
+type GetWatchedWorksViewerUser struct {
+	Works GetWatchedWorksViewerUserWorksWorkConnection `json:"works"`
+}
+
+// GetWorks returns GetWatchedWorksViewerUser.Works, and is useful for accessing the field via an interface.
+func (v *GetWatchedWorksViewerUser) GetWorks() GetWatchedWorksViewerUserWorksWorkConnection {
+	return v.Works
+}
+
+// GetWatchedWorksViewerUserWorksWorkConnection includes the requested fields of the GraphQL type WorkConnection.
+// The GraphQL type's documentation follows.
+//
+// The connection type for Work.
+type GetWatchedWorksViewerUserWorksWorkConnection struct {
+	// A list of nodes.
+	Nodes []GetWatchedWorksViewerUserWorksWorkConnectionNodesWork `json:"nodes"`
+}
+
+// GetNodes returns GetWatchedWorksViewerUserWorksWorkConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *GetWatchedWorksViewerUserWorksWorkConnection) GetNodes() []GetWatchedWorksViewerUserWorksWorkConnectionNodesWork {
+	return v.Nodes
+}
+
+// GetWatchedWorksViewerUserWorksWorkConnectionNodesWork includes the requested fields of the GraphQL type Work.
+// The GraphQL type's documentation follows.
+//
+// An anime title
+type GetWatchedWorksViewerUserWorksWorkConnectionNodesWork struct {
+	AnnictId   int                                                                            `json:"annictId"`
+	Title      string                                                                         `json:"title"`
+	SeasonName SeasonName                                                                     `json:"seasonName"`
+	SeasonYear int                                                                            `json:"seasonYear"`
+	Programs   GetWatchedWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection `json:"programs"`
+}
+
+// GetAnnictId returns GetWatchedWorksViewerUserWorksWorkConnectionNodesWork.AnnictId, and is useful for accessing the field via an interface.
+func (v *GetWatchedWorksViewerUserWorksWorkConnectionNodesWork) GetAnnictId() int { return v.AnnictId }
+
+// GetTitle returns GetWatchedWorksViewerUserWorksWorkConnectionNodesWork.Title, and is useful for accessing the field via an interface.
+func (v *GetWatchedWorksViewerUserWorksWorkConnectionNodesWork) GetTitle() string { return v.Title }
+
+// GetSeasonName returns GetWatchedWorksViewerUserWorksWorkConnectionNodesWork.SeasonName, and is useful for accessing the field via an interface.
+func (v *GetWatchedWorksViewerUserWorksWorkConnectionNodesWork) GetSeasonName() SeasonName {
+	return v.SeasonName
+}
+
+// GetSeasonYear returns GetWatchedWorksViewerUserWorksWorkConnectionNodesWork.SeasonYear, and is useful for accessing the field via an interface.
+func (v *GetWatchedWorksViewerUserWorksWorkConnectionNodesWork) GetSeasonYear() int {
+	return v.SeasonYear
+}
+
+// GetPrograms returns GetWatchedWorksViewerUserWorksWorkConnectionNodesWork.Programs, and is useful for accessing the field via an interface.
+func (v *GetWatchedWorksViewerUserWorksWorkConnectionNodesWork) GetPrograms() GetWatchedWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection {
+	return v.Programs
+}
+
+// GetWatchedWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection includes the requested fields of the GraphQL type ProgramConnection.
+// The GraphQL type's documentation follows.
+//
+// The connection type for Program.
+type GetWatchedWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection struct {
+	// A list of nodes.
+	Nodes []GetWatchedWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram `json:"nodes"`
+}
+
+// GetNodes returns GetWatchedWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *GetWatchedWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnection) GetNodes() []GetWatchedWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram {
+	return v.Nodes
+}
+
+// GetWatchedWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram includes the requested fields of the GraphQL type Program.
+type GetWatchedWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram struct {
+	StartedAt time.Time `json:"startedAt"`
+}
+
+// GetStartedAt returns GetWatchedWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram.StartedAt, and is useful for accessing the field via an interface.
+func (v *GetWatchedWorksViewerUserWorksWorkConnectionNodesWorkProgramsProgramConnectionNodesProgram) GetStartedAt() time.Time {
+	return v.StartedAt
+}
+
 // GetWatchingWorksResponse is returned by GetWatchingWorks on success.
 type GetWatchingWorksResponse struct {
 	Viewer GetWatchingWorksViewerUser `json:"viewer"`
@@ -499,6 +588,49 @@ func GetWannaWatchWorks(
 	var err_ error
 
 	var data_ GetWannaWatchWorksResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by GetWatchedWorks.
+const GetWatchedWorks_Operation = `
+query GetWatchedWorks {
+	viewer {
+		works(state: WATCHED) {
+			nodes {
+				annictId
+				title
+				seasonName
+				seasonYear
+				programs(first: 1) {
+					nodes {
+						startedAt
+					}
+				}
+			}
+		}
+	}
+}
+`
+
+func GetWatchedWorks(
+	ctx_ context.Context,
+	client_ graphql.Client,
+) (*GetWatchedWorksResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "GetWatchedWorks",
+		Query:  GetWatchedWorks_Operation,
+	}
+	var err_ error
+
+	var data_ GetWatchedWorksResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/annict/query.graphql
+++ b/annict/query.graphql
@@ -36,7 +36,25 @@ query GetWatchingWorks {
 
 query GetOnHoldWorks {
   viewer {
-    works(state: WATCHING){
+    works(state: ON_HOLD){
+      nodes {
+        annictId
+        title
+        seasonName
+        seasonYear
+        programs (first: 1) {
+          nodes {
+            startedAt
+          }
+        }
+      }
+    }
+  }
+}
+
+query GetStopWatchingWorks {
+  viewer {
+    works(state: STOP_WATCHING){
       nodes {
         annictId
         title

--- a/annict/query.graphql
+++ b/annict/query.graphql
@@ -69,3 +69,21 @@ query GetStopWatchingWorks {
     }
   }
 }
+
+query GetWatchedWorks {
+  viewer {
+    works(state: WATCHED){
+      nodes {
+        annictId
+        title
+        seasonName
+        seasonYear
+        programs (first: 1) {
+          nodes {
+            startedAt
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -57,10 +57,10 @@ var syncCmd = &cli.Command{
 			Usage: "enable fallback VOD detection when specific VOD section is not found (searches all page links with filtering)",
 			Value: false,
 		},
-		// enable stop watching rule removal
+		// enable recording rule removal
 		&cli.BoolFlag{
-			Name:  "enable-stop-watching-removal",
-			Usage: "enable automatic removal of recording rules when anime is marked as STOP_WATCHING on Annict",
+			Name:  "enable-rule-removal",
+			Usage: "enable automatic removal of recording rules when anime is marked as STOP_WATCHING or WATCHED on Annict",
 			Value: false,
 		},
 	},
@@ -68,7 +68,7 @@ var syncCmd = &cli.Command{
 		// Parse excluded VOD services
 		excludedVODServices := c.StringSlice("exclude-vod-services")
 		enableVODFallback := c.Bool("enable-vod-fallback")
-		enableStopWatchingRemoval := c.Bool("enable-stop-watching-removal")
+		enableRuleRemoval := c.Bool("enable-rule-removal")
 
 		s, err := syncer.NewSyncer(
 			syncer.WithAnnictAPIToken(c.String(string(annictAPITokenFlag))),
@@ -77,7 +77,7 @@ var syncCmd = &cli.Command{
 			syncer.WithDBPath(c.String("db-path")),
 			syncer.WithExcludedVODServicesFromStrings(excludedVODServices),
 			syncer.WithVODFallback(enableVODFallback),
-			syncer.WithStopWatchingRemoval(enableStopWatchingRemoval),
+			syncer.WithRuleRemoval(enableRuleRemoval),
 		)
 		if err != nil {
 			return err

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -57,11 +57,18 @@ var syncCmd = &cli.Command{
 			Usage: "enable fallback VOD detection when specific VOD section is not found (searches all page links with filtering)",
 			Value: false,
 		},
+		// enable stop watching rule removal
+		&cli.BoolFlag{
+			Name:  "enable-stop-watching-removal",
+			Usage: "enable automatic removal of recording rules when anime is marked as STOP_WATCHING on Annict",
+			Value: false,
+		},
 	},
 	Action: func(c *cli.Context) error {
 		// Parse excluded VOD services
 		excludedVODServices := c.StringSlice("exclude-vod-services")
 		enableVODFallback := c.Bool("enable-vod-fallback")
+		enableStopWatchingRemoval := c.Bool("enable-stop-watching-removal")
 
 		s, err := syncer.NewSyncer(
 			syncer.WithAnnictAPIToken(c.String(string(annictAPITokenFlag))),
@@ -70,6 +77,7 @@ var syncCmd = &cli.Command{
 			syncer.WithDBPath(c.String("db-path")),
 			syncer.WithExcludedVODServicesFromStrings(excludedVODServices),
 			syncer.WithVODFallback(enableVODFallback),
+			syncer.WithStopWatchingRemoval(enableStopWatchingRemoval),
 		)
 		if err != nil {
 			return err

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -41,12 +41,12 @@ type syncer struct {
 }
 
 type options struct {
-	AnnictEndpoint           string
-	AnnictAPIToken           string
-	EPGStationEndpoint       string
-	DBPath                   string
-	ExcludedVODServices      []vod.StreamingService
-	EnableVODFallback        bool
+	AnnictEndpoint            string
+	AnnictAPIToken            string
+	EPGStationEndpoint        string
+	DBPath                    string
+	ExcludedVODServices       []vod.StreamingService
+	EnableVODFallback         bool
 	EnableStopWatchingRemoval bool
 }
 
@@ -106,12 +106,12 @@ func WithStopWatchingRemoval(enabled bool) Option {
 
 func NewSyncer(opts ...Option) (Interface, error) {
 	o := options{
-		AnnictEndpoint:           defaultAnnictEndpoint,
-		AnnictAPIToken:           "",
-		EPGStationEndpoint:       defaultEPGStationEndpoint,
-		DBPath:                   defaultDBPath,
-		ExcludedVODServices:      []vod.StreamingService{},
-		EnableVODFallback:        false,
+		AnnictEndpoint:            defaultAnnictEndpoint,
+		AnnictAPIToken:            "",
+		EPGStationEndpoint:        defaultEPGStationEndpoint,
+		DBPath:                    defaultDBPath,
+		ExcludedVODServices:       []vod.StreamingService{},
+		EnableVODFallback:         false,
 		EnableStopWatchingRemoval: false,
 	}
 	for _, opt := range opts {
@@ -449,16 +449,16 @@ func (s *syncer) removeRuleFromEPGStation(ctx context.Context, work annictWork) 
 
 	for _, ruleID := range ruleIDs {
 		slog.Debug("removing recording rule from EPGStation", slog.String("annict_work_title", work.Title), slog.String("annict_work_id", work.ID), slog.Int("rule_id", int(ruleID)))
-		
+
 		r, err := s.esClient.DeleteRulesRuleId(ctx, int(ruleID))
 		if err != nil {
 			return fmt.Errorf("failed to delete recording rule %d for work %s: %w", ruleID, work.ID, err)
 		}
-		
+
 		if r.StatusCode != http.StatusOK && r.StatusCode != http.StatusNoContent {
 			return fmt.Errorf("failed to delete recording rule %d for work %s: got status %d", ruleID, work.ID, r.StatusCode)
 		}
-		
+
 		slog.Info("removed recording rule from EPGStation", slog.String("annict_work_title", work.Title), slog.String("annict_work_id", work.ID), slog.Int("rule_id", int(ruleID)))
 		syncerRecordingRuleSynced.WithLabelValues(strconv.Itoa(int(ruleID)), work.ID).Set(0)
 	}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -185,21 +185,21 @@ func (s *syncer) sync(ctx context.Context) error {
 	// Handle STOP_WATCHING and WATCHED works - remove recording rules (only if enabled)
 	if s.enableRuleRemoval {
 		var worksToRemove []annictWork
-		
+
 		// Get STOP_WATCHING works
 		if stopWatchingWorks, err := s.getStopWatchingWorks(ctx); err != nil {
 			return err
 		} else {
 			worksToRemove = append(worksToRemove, stopWatchingWorks...)
 		}
-		
+
 		// Get WATCHED works
 		if watchedWorks, err := s.getWatchedWorks(ctx); err != nil {
 			return err
 		} else {
 			worksToRemove = append(worksToRemove, watchedWorks...)
 		}
-		
+
 		// Remove rules for all works
 		if err := s.removeRulesFromEPGStation(ctx, worksToRemove); err != nil {
 			return err


### PR DESCRIPTION
## Summary

Implements automatic removal of EPGStation recording rules when users mark anime as `STOP_WATCHING` or `WATCHED` on Annict. This addresses issue #4 with enhanced functionality.

**⚠️ Breaking Change Prevention**: This feature is **opt-in** and disabled by default to prevent unexpected behavior for existing users.

## Changes

- **Add GraphQL queries** for both STOP_WATCHING and WATCHED statuses from Annict API
  - `GetStopWatchingWorks` - fetches anime user stopped watching
  - `GetWatchedWorks` - fetches anime user completed watching
- **Implement comprehensive rule removal functionality** including:
  - `removeRulesFromEPGStation()` to process all works requiring rule removal
  - `removeRuleFromEPGStation()` to delete individual recording rules via EPGStation API
  - `deleteRecordingRuleIDsByAnnictWorkID()` for database cleanup
- **Add generic CLI flag `--enable-rule-removal`** to make the feature opt-in (defaults to false)
- **Enhanced sync process** to handle both STOP_WATCHING and WATCHED works when flag is enabled
- **Fix existing bug** where GetOnHoldWorks query was incorrectly using `WATCHING` instead of `ON_HOLD`

## Usage

```bash
# Enable recording rule removal for both STOP_WATCHING and WATCHED anime
./annict-epgstation-connector sync --enable-rule-removal

# Combine with other features
./annict-epgstation-connector sync --exclude-vod-services netflix,hulu --enable-vod-fallback --enable-rule-removal

# Default behavior (without flag) - no recording rules are removed
./annict-epgstation-connector sync
```

## Technical Details

The implementation follows existing code patterns:
- Uses EPGStation's `DELETE /rules/{ruleId}` API endpoint to remove recording rules
- Maintains database consistency by removing work-to-rule mappings after successful deletion
- Includes proper error handling, structured logging, and Prometheus metrics updates
- Processes rule removal after rule creation to avoid conflicts
- **Feature is gated behind generic CLI flag** to ensure backward compatibility
- **Combines both work types** into single removal operation for efficiency

## Rule Removal Logic

When `--enable-rule-removal` is specified:
1. **Fetch STOP_WATCHING works** - anime user explicitly stopped watching
2. **Fetch WATCHED works** - anime user completed watching
3. **Combine both lists** for batch processing
4. **Remove recording rules** for all applicable works
5. **Clean up database mappings** to maintain consistency

This approach ensures that recording rules are removed for anime that no longer need active recording, whether because the user stopped watching mid-series or completed the entire series.

## Test Plan

- [x] Build succeeds without compilation errors
- [x] E2E tests pass (though currently empty)
- [x] CLI flag appears correctly in help output with updated description
- [x] Default behavior unchanged when flag not specified
- [x] Both STOP_WATCHING and WATCHED works are processed when flag is enabled
- [ ] Manual testing with actual Annict API and EPGStation instance
- [ ] Verify database cleanup works correctly for both work types
- [ ] Check metrics are updated properly when rules are removed

## Backward Compatibility

✅ **Fully backward compatible** - existing users will see no changes unless they explicitly use the new `--enable-rule-removal` flag. The feature is disabled by default.

## Migration Path

Users who want to enable automatic rule removal can add the `--enable-rule-removal` flag to their existing commands. No other changes required.

The new flag name is more generic and accurately reflects that it handles multiple completion statuses, not just STOP_WATCHING.

Fixes #4